### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,126 @@
-# app-dev
-My first repository
+# Katekyo Hitman Reborn!
+
+### Overview
+
+Katekyo Hitman Reborn! is a Japanese anime series based on the manga of the same name by Akira Amano. The series follows the life of Tsunayoshi “Tsuna” Sawada, a teenage boy who is chosen to become the next boss of the Vongola Family, a powerful Mafia organization. With the help of his tutor, Reborn, Tsuna must train to become a skilled Mafia boss and protect his friends and family from rival gangs.
+
+The overall plot of the series centers around the primary protagonist, a teenage boy named Tsunayoshi Sawada, constantly known for being a loser meets an infant hitman known as Reborn, who acts as his home tutor in order to train him to become the Tenth Boss of a Mafia Famiglia known as Vongola Famiglia.
+
+### Seansons & Episodes
+
+The series has a total of 200 episodes.
+| Season | Episode |
+| ----------- | ----------- |
+| 1 | 33 |
+| 2 | 32 |
+| 3 | 8 |
+| 4 | 28 |
+| 5 | 39 |
+| 6 | 13 |
+| 7 | 24 |
+| 8 | 12 |
+| 9 | 14 |
+
+### Characters
+
+**Tsunayoshi “Tsuna” Sawada**
+
+![image](https://github.com/irisjeremy10/app-dev/assets/157128505/51c8b08d-0849-4e4e-a47e-aec49949dbfe
+)
+
+1. Personality
+
+Tsuna is normally insecure, considering himself a loser, and has a crush on Kyoko Sasagawa, seeing her as the only reason to go to school. He is also known for his poor grades, bad luck, and lack of athleticism. However, with Reborn’s help, Tsuna confronts his fears and befriends several people, some of which become his guardians within the Vongola Family.
+
+2. Abilities
+  
+Tsuna is capable of using the Dying Will Flame, which is a form of high pressured energy capable of having destructive powers or purifying evil auras. When shot with the Vongola Family’s Dying Will Bullet, he returns as a powerful berserker who aims to act on his regrets to make it right. However, if he does not regret anything when shot, he will die.
+
+3. Appearance
+  
+Tsuna is a short and slim teenage boy with spiky brown hair and orange eyes (brown in the anime) 2. He is also noted to have inherited many traits from Giotto, and his own mother.
+
+**Vongola Family**
+
+The Vongola Family is a powerful mafia family in Italy, and the most prominent one in the anime series **Reborn!**. The Vongola Famiglia is led by the *Vongola Nono, Timoteo,* but will soon be succeeded by the Vongola Decimo in training, Tsunayoshi Sawada. The Vongola Decimo and his guardians are the tenth generation Boss and Guardians of the Vongola Famiglia. They were all accepted as guardians by the first generation Guardians and inherited the Original Vongola Rings, an accomplishment that the eight generations prior had not achieved. The tenth generation of the Vongola Family consists of the following members:
+
+![image](https://github.com/irisjeremy10/app-dev/assets/157128505/b055802c-a3c1-4db9-a906-83564e76450e)
+
+
+- Tsunayoshi Sawada, the Vongola Decimo, who is the lead boss.
+- Reborn, his home tutor.
+- Gokudera Hayato, the Storm Guardian.
+- Yamamoto Takeshi, the Rain Guardian.
+- Sasagawa Ryohei, the Sun Guardian.
+- Lambo, the Lightning Guardian.
+- Hibari Kyoya, the Cloud Guardian.
+- Chrome Dokuro, the Mist Guardian
+
+The Vongola Family has a unique tradition of selecting heirs and guardians, which includes an Inheritance Ceremony. The Vongola Family has several powerful weapons, including the Vongola Ring, Vongola Box Weapon, and Vongola Messenger Bird.
+
+**Arcobaleno**
+
+![image](https://github.com/irisjeremy10/app-dev/assets/157128505/b7c8ed20-f49c-4df6-8311-b32c99134523)
+
+The Arcobaleno is a group of seven babies in the anime and manga series Katekyo Hitman Reborn. They are known as the world’s strongest seven and are each named after a color of the rainbow. The members of the Arcobaleno are cursed infants who were given special pacifiers that keep them in their infant state. Each member has a unique ability, and they are all powerful enough to be considered legendary.
+
+**Varia**
+
+![image](https://github.com/irisjeremy10/app-dev/assets/157128505/f21edc13-381f-4c29-9ece-4d0f235eaa09)
+
+The Varia is an elite independent assassination squad under the Vongola Famiglia. They are genius assassins who work in the deepest recesses of the Mafia. They are synonymous for their skill, which is called “Varia Quality.” Their flag contains the text Squadra killer autonoma di Vongola IX, lit. “Autonomous Assassination Team of Vongola IX”. Each member takes on missions that are said to be impossible to accomplish by humans; however, they do not accept a mission unless the chance of success is 90% or higher. Those that see them work often say that their high-level assassination skills are demonic. The Varia are said to kill any member who fails in order to eliminate weakness, which is why the Varia are the strongest of all.
+
+**CEDEF**
+
+![image](https://github.com/irisjeremy10/app-dev/assets/157128505/0a73f221-1168-4279-b71b-982a574be421)
+
+The CEDEF is a secret intelligence organization independent from but still under the Vongola Famiglia. Its headquarters is disguised as an ordinary business’s building. CEDEF stands for Consulenza Esterna Della Famiglia (門外顧問機関, Mongai komon kikan?) meaning “External Advisors of the Family”. The CEDEF is responsible for managing the Vongola’s financial and political affairs, as well as providing intelligence and support to the Vongola’s boss and guardians. The CEDEF is led by Iemitsu Sawada, the father of Tsunayoshi Sawada, the protagonist of the series.
+
+**Vongla Members**
+
+![image](https://github.com/irisjeremy10/app-dev/assets/157128505/aa13d02f-c560-46b3-9842-41631bf374f6)
+
+
+- I-pin
+
+A young assassin from Hong Kong, who had been tasked with assassinating a target in Japan. She is also known as the "Human Bomb" due to her special technique, the *Pinzu-Timed Super Explosion*. 
+
+- Bianchi
+
+An Italian freelance hitman known by the nickname "Poison Scorpion". She is the older paternal half-sister to Hayato Gokudera. She is Reborn's fourth lover[6] and former associate. 
+
+- Gianini
+
+Giannini is the son of Giannichi from the Vongola Famiglia that focuses on engineering. Weapon tuning, modification, and creation is no problem for Giannini's family because they have been supplying the Vongola with specialized Weapons for many generations.
+  
+- Futa
+
+Futa, also known as Futa de la Stella, lit. "Futa of the Stars", is a young boy who ranks people by their abilities in his Ranking Book. He has an extremely wide range of knowledge on thousands of people. Considered to be an invaluable informant for the mafia, Futa is sometimes being paid insane amounts of money for a copy of certain rankings.
+
+- Kyoko Sasagawa
+
+Kyoko Sasagawa is a Namimori Middle School student where she is the most popular girl there. That Kyoko is kind in her nature may be partly why she is admired by Tsunayoshi Sawada. She is the younger sister of Ryohei Sasagawa who she is close to. At school, Kyoko is friends with Hana Kurokawa. Due to a shared fondness of cakes, she would befriend Haru Miura outside of classes.
+
+- Haru Miura
+
+Haru Miura is a Midori Middle School student who likes Tsunayoshi Sawada. Quite quickly, Haru becomes besotted with her newfound dream of becoming his Mafia wife. Plucky in her nature, Haru is ready to be involved with what Reborn usually arranges. A talented gymnast, that Haru is also daring is of help in such instances.
+
+- Tetsuya Kusakabe
+
+Tetsuya Kusakabe is the second-in-command of the Namimori Middle Disciplinary Committee. He is extremely loyal to Kyoya Hibari, both of who are characters in the Katekyo Hitman Reborn! series. It is the same in the future when Kusakabe is the second-in-command of the Foundation. A member of this, Kusakabe has travelled around the world with Hibari researching the Rings and Box Weapons.
+
+- Spanner
+
+Spanner was an engineer in the Millefiore's Tech Department at the Merone Base and was a B-Ranked officer of the Black Spell.[2] He invented the Contact Lenses and gave it to Tsunayoshi Sawada to perfect the X-Burner.
+
+- Shoichi Irie
+Shoichi Irie is a resident of Namimori that frequently encounters Tsunayoshi Sawada and his family. In the future, Shoichi becomes a member of the Millefiore Famiglia, under Byakuran.
+
+### Manga
+
+The manga has been serialized in the shōnen manga anthology Weekly Shōnen Jump by Shueisha since its premiere on May 31, 2004 and ran until its conclusion on November 12, 2012, with the final 42nd volume released in March 2013.
+
+The chapters of the manga series Reborn! are referred to as a “Target” (標的, Tāgetto) and have been published in tankōbon volumes by Shueisha. The first volume was released on October 4, 2004, and forty-two volumes have been released in total.
+
+*The images is not mine. Photo Credits to its owner.*
+That is all! 😄 😸


### PR DESCRIPTION
The anime adaptation of the manga series, also known as Katekyō Hitman Reborn!, was directed by Kenichi Imaizumi and produced and animated by Artland. It first began airing on TV Tokyo in Japan on October 7, 2006, and has since broadcast over 200 episodes, which are each referred to as a “Target”

 @sti-admin